### PR TITLE
Fix scroll control (add -P option).

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -67,7 +67,7 @@ Item {
     // - commands
     property string redshiftCommand: 'redshift' + locationCmdPart + modeCmdPart + ' -t ' + dayTemperature + ':' + nightTemperature + brightnessAndGamma + (smoothTransitions ? '' : ' -r')
     property string redshiftOneTimeBrightnessAndGamma: ' -b ' + (currentBrightness*0.01).toFixed(2) + ':' + (currentBrightness*0.01).toFixed(2) + ' -g ' + gammaR + ':' + gammaG + ':' + gammaB
-    property string redshiftOneTimeCommand: 'redshift -O ' + manualTemperature + redshiftOneTimeBrightnessAndGamma + ' -r'
+    property string redshiftOneTimeCommand: 'redshift -P -O ' + manualTemperature + redshiftOneTimeBrightnessAndGamma + ' -r'
     property string redshiftPrintCommand: 'LANG=C ' + redshiftCommand + ' -p'
 
     property bool inTray: (plasmoid.parent === null || plasmoid.parent.objectName === 'taskItemContainer')


### PR DESCRIPTION
I find out that the screen gets darker every time I'm using the scroll control, no matter the direction. It has been mentionned here [https://github.com/kotelnik/plasma-applet-redshift-control/issues/55](https://github.com/kotelnik/plasma-applet-redshift-control/issues/55).

I fixed that by using the `-P` option to the `redshiftOneTimeCommand`.